### PR TITLE
WIP GDAX Deposit implementation, current scoping issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Take a look at `serverless.yml`. The relevant sections are listed below.
 
   environment:
     ...
+    DEPOSIT_AMOUNT: 15    # The amount of fiat you wish to deposit
     FIAT_AMOUNT: 15       # The amount of fiat you wish to exchange for crypto
     FIAT_TYPE: 'USD'      # The type of fiat you plan to use. Also supports EUR/GBP
 ...
@@ -94,7 +95,7 @@ functions:
 
 ```
 
-So with the default settings, gdax-lambda-buyer will buy $5 worth of Bitcoin, Ethereum and Litecoin (totaling $15 spent) every week.
+So with the default settings, gdax-lambda-buyer will buy $5 worth of Bitcoin, Ethereum and Litecoin (totaling $15 spent) every week. It will also deposit $15 every week.
 
 You can also replace `FIAT_AMOUNT=15` with `CRYPTO_AMOUNT=3` and buy 1 BTC, ETH and LTC each every week. Change to 100 and you'd buy 33.333 each, etc. The possibilities are endless (as long as your bank account is 💸).
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Next, create a file called `credentials.json` with the following contents:
 }
 ```
 
+If only using the purchase features the API scopes required are: `trade`
+
+If also using the deposit features the `transfer` scope is also required.
+
 Save and close. This file is listed in .gitignore so you don't have to worry about accidentally checking it in to Git.
 
 ### Adjust Parameters

--- a/gdax-node/lib/clients/authenticated.js
+++ b/gdax-node/lib/clients/authenticated.js
@@ -240,9 +240,18 @@ class AuthenticatedClient extends PublicClient {
     return this.post(['position/close'], { body: params }, callback);
   }
 
-  deposit(params, callback) {
+  depositCoinbase(params, callback) {
     this._requireParams(params, ['amount', 'currency', 'coinbase_account_id']);
     return this.post(['deposits/coinbase-account'], { body: params }, callback);
+  }
+
+  depositPaymentMethod(params, callback) {
+    this._requireParams(params, ['amount', 'currency', 'payment_method_id']);
+    return this.post(
+      ['deposits/payment-method'],
+      { body: params },
+      callback
+    );
   }
 
   withdraw(params, callback) {
@@ -258,6 +267,11 @@ class AuthenticatedClient extends PublicClient {
     this._requireParams(body, ['amount', 'currency', 'crypto_address']);
     return this.post(['withdrawals/crypto'], { body }, callback);
   }
+
+  getPaymentMethods(callback) {
+    return this.get(['payment-methods'], callback);
+  }
+
 
   _requireParams(params, required) {
     for (let param of required) {

--- a/handler.js
+++ b/handler.js
@@ -1,6 +1,16 @@
 const Gdax = require('./gdax-node')
 const authedClient = new Gdax.AuthenticatedClient(process.env.GDAX_API_KEY, process.env.GDAX_API_SECRET, process.env.GDAX_PASSPHRASE, process.env.GDAX_URI)
 
+export const deposit = async (event, context, callback) => {
+  try {
+    let deposit = await depositFromBank()
+    console.log(deposit)
+    succeed(context)
+  } catch (err) {
+    fail(context, err)
+  }
+}
+
 export const buyBitcoin = async (event, context, callback) => {
   try {
     let order = await buy('BTC')
@@ -31,7 +41,34 @@ export const buyLitecoin = async (event, context, callback) => {
   }
 }
 
-async function buy (cryptoType) {
+async function depositFromBank() {
+  if (process.env.DEPOSIT_AMOUNT) {
+    try {
+      let paymentMethodsResponse = await paymentMethods();
+      for (var i = 0; i < paymentMethodsResponse.length; i++) {
+        if (paymentMethodsResponse[i].currency == process.env.FIAT_TYPE && paymentMethodsResponse[i].type == 'ach_bank_account') {
+          var paymentMethodId = paymentMethodsResponse[i].id
+        }
+      }
+
+      const depositParams = {
+        'amount': process.env.DEPOSIT_AMOUNT,
+        'currency': process.env.FIAT_TYPE,
+        'payment_method_id': paymentMethodId
+      }
+      return authedClient.depositPaymentMethod(depositParams)
+    } catch (err) {
+      console.log(err)
+    }
+  } else throw new Error('Must specify DEPOSIT_AMOUNT')
+
+}
+
+async function paymentMethods() {
+  return authedClient.getPaymentMethods();
+}
+
+async function buy(cryptoType) {
   let params = {
     'product_id': `${cryptoType}-${process.env.FIAT_TYPE}`
   }
@@ -43,11 +80,13 @@ async function buy (cryptoType) {
   } else throw new Error('Must specify either FIAT_AMOUNT or CRYPTO_AMOUNT')
 }
 
-function succeed (context) {
-  context.succeed({ statusCode: 200 })
+function succeed(context) {
+  context.succeed({
+    statusCode: 200
+  })
 }
 
-function fail (context, err) {
+function fail(context, err) {
   console.log(err)
   context.fail(err)
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "eth": "serverless invoke local --function buyEthereum --stage prod",
     "ltc": "serverless invoke local --function buyLitecoin --stage prod",
     "test": "serverless invoke local --function buyBitcoin --stage dev",
+    "deposit": "serverless invoke local --function deposit --stage dev",
     "deploy": "serverless deploy --stage prod"
   },
   "author": "Alfonso Gober <alfonso.gober.jr@gmail.com>",

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,18 +32,18 @@ functions:
     handler: handler.deposit
     events:
       - schedule: rate(7 days)
-  # buyBitcoin:
-  #   handler: handler.buyBitcoin
-  #   events:
-  #     - schedule: rate(7 days)
-  # buyEthereum:
-  #   handler: handler.buyEthereum
-  #   events:
-  #     - schedule: rate(7 days)
-  # buyLitecoin:
-  #   handler: handler.buyLitecoin
-  #   events:
-  #     - schedule: rate(7 days)
+  buyBitcoin:
+    handler: handler.buyBitcoin
+    events:
+      - schedule: rate(7 days)
+  buyEthereum:
+    handler: handler.buyEthereum
+    events:
+      - schedule: rate(7 days)
+  buyLitecoin:
+    handler: handler.buyLitecoin
+    events:
+      - schedule: rate(7 days)
 
 plugins:
   - serverless-webpack

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,8 +16,8 @@ provider:
     GDAX_API_KEY: ${file(./credentials.json):${self:custom.stage}.gdaxAPIKey}
     GDAX_API_SECRET: ${file(./credentials.json):${self:custom.stage}.gdaxAPISecret}
     GDAX_URI: ${file(./credentials.json):${self:custom.stage}.gdaxURI}
-    DEPOSIT_AMOUNT: 20
-    FIAT_AMOUNT: 200
+    DEPOSIT_AMOUNT: 15
+    FIAT_AMOUNT: 15
     FIAT_TYPE: 'USD'
   iamRoleStatements:
     - Effect: "Allow"

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,7 +16,8 @@ provider:
     GDAX_API_KEY: ${file(./credentials.json):${self:custom.stage}.gdaxAPIKey}
     GDAX_API_SECRET: ${file(./credentials.json):${self:custom.stage}.gdaxAPISecret}
     GDAX_URI: ${file(./credentials.json):${self:custom.stage}.gdaxURI}
-    FIAT_AMOUNT: 15
+    DEPOSIT_AMOUNT: 20
+    FIAT_AMOUNT: 200
     FIAT_TYPE: 'USD'
   iamRoleStatements:
     - Effect: "Allow"
@@ -27,18 +28,22 @@ provider:
       Resource: "*"
 
 functions:
-  buyBitcoin:
-    handler: handler.buyBitcoin
+  deposit:
+    handler: handler.deposit
     events:
       - schedule: rate(7 days)
-  buyEthereum:
-    handler: handler.buyEthereum
-    events:
-      - schedule: rate(7 days)
-  buyLitecoin:
-    handler: handler.buyLitecoin
-    events:
-      - schedule: rate(7 days)
+  # buyBitcoin:
+  #   handler: handler.buyBitcoin
+  #   events:
+  #     - schedule: rate(7 days)
+  # buyEthereum:
+  #   handler: handler.buyEthereum
+  #   events:
+  #     - schedule: rate(7 days)
+  # buyLitecoin:
+  #   handler: handler.buyLitecoin
+  #   events:
+  #     - schedule: rate(7 days)
 
 plugins:
   - serverless-webpack


### PR DESCRIPTION
Attempt to implement a recurring deposit from a linked bank account on GDAX

Added the required methods into gdax-node package.

Currently this fails due to API scoping issues when calling the GDAX `deposits/payment-method` endpoint. I have been unable to get my Sandbox API with the proper scopes for this endpoint. Once the scoping is sorted this method should be able to take a new `DEPOSIT_AMOUNT` environment variable and deposit that amount from a linked bank account of the desired `FIAT_TYPE`